### PR TITLE
Enable experimental TradingView horizontal line drawing support

### DIFF
--- a/app/routes/perp.$symbol.tsx
+++ b/app/routes/perp.$symbol.tsx
@@ -37,6 +37,17 @@ export default function PerpPage() {
     },
     [navigate, searchParams]
   );
+// Temporary enhancement: enable horizontal line drawings on TradingView chart
+useEffect(() => {
+  const interval = setInterval(() => {
+    const tvWidget = window.tvWidget || window.tradingViewWidget;
+    if (tvWidget && tvWidget.activeChart) {
+      tvWidget.activeChart().createHorizontalLine(50000, { color: "#22ab94" });
+      clearInterval(interval);
+    }
+  }, 3000);
+  return () => clearInterval(interval);
+}, []);
 
   return (
     <TradingPage


### PR DESCRIPTION
This update introduces an experimental TradingView enhancement to enable horizontal line drawing on charts within the perp.$symbol.tsx route.

Implementation details:

Added a useEffect hook that periodically checks for the TradingView widget (window.tvWidget).

Once the widget is detected, a test horizontal line is programmatically created at a fixed price level.

The interval automatically clears after execution to prevent memory leaks.

Purpose:
This change serves as a temporary proof-of-concept to verify that TradingView chart customization is working correctly, providing the foundation for adding advanced charting features once the TradingView Advanced Charts license is approved for the custom domain.

Cleanup Note:
This enhancement is experimental and should be removed or refactored once advanced charting capabilities are officially enabled. The current line-drawing logic is meant for testing only and not intended for production use.