### PR TITLE
fix: evm initial config appMetadata

### DIFF
--- a/app/utils/walletConfig.ts
+++ b/app/utils/walletConfig.ts
@@ -117,6 +117,10 @@ export const getEvmInitialConfig = () => {
     ? {
         options: {
           wallets,
+          appMetadata: {
+            name: getRuntimeConfig("VITE_ORDERLY_BROKER_NAME"),
+            description: getRuntimeConfig("VITE_ORDERLY_BROKER_NAME"),
+          },
         },
       }
     : undefined;


### PR DESCRIPTION
This PR sets the WalletConnect broker name to appMetadata instead of default "Orderly" [https://github.com/OrderlyNetwork/js-sdk/blob/273a901d2bb48ef6552273c4cd885ccb938166b5/packages/wallet-connector/src/config.ts#L26-L28](https://github.com/OrderlyNetwork/js-sdk/blob/273a901d2bb48ef6552273c4cd885ccb938166b5/packages/wallet-connector/src/config.ts#L26-L28)